### PR TITLE
Masupa infrastructure create datasets in data warehouse

### DIFF
--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,0 +1,28 @@
+### Overview
+Here, I provide instructions on how to reproduce the project on the infrastructure side. Please read through carefully, and make sure you have everything setup before running this.
+
+### 1. Initial Requirements
+- [x] `GCP Project Created`:
+    - Service Accounted created and key is downloaded
+
+### 2. Terraform Setup
+- Please follow this link to see installation depending on your machine: [Terraform installation](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+
+### 3. How to run
+
+- Navigate to directory containing `terraform` file
+- In the `terminal`, run the following commands:
+    - `terraform init:` This command initialize a working directory containing Terraform configuration files.
+    - `terraform plan:` This command creates an execution plan, which lets you preview the changes that Terraform plans to make to your infrastructure.
+        - In the terminal, you will be prompted to paste the location of your service account credentials
+        - In addition, you will be required to enter your GCP Project ID
+    - `terraform apply:` command executes the actions proposed in a Terraform plan.
+
+### Note:
+- `terraform init` should be run only once.
+- `terraform plan` should be executed any time changes have been made to the terraform files.
+- `terraform apply` should be executed to ineffect changes in the GCP.
+
+### Resources:
+- [What is Infrastructure as Code with Terraform](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/infrastructure-as-code)
+- [Terraform Tutorials](https://developer.hashicorp.com/tutorials/library?product=terraform)

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -33,3 +33,16 @@ resource "google_bigquery_dataset" "epl_dataset" {
   project    = var.project
   location   = var.region
 }
+
+# Player Stats Table
+resource "google_bigquery_table" "player_stats_data" {
+  project = var.project
+  dataset_id = var.big_query_dataset
+  table_id = "player_stats_data"
+
+  schema = local.player_stats_schema
+
+  # Define clustering configuration
+  clustering = ["Season"]
+
+  }

--- a/infrastructure/terraform/resources/schema/player_stats_data.json
+++ b/infrastructure/terraform/resources/schema/player_stats_data.json
@@ -1,0 +1,67 @@
+[
+    {
+      "name":"Player",
+      "type":"STRING",
+      "description": "Player full names"
+    },
+    {
+      "name":"Mins",
+      "type":"STRING",
+      "description": "Minutes played"
+    },
+    {
+      "name":"Goals",
+      "type":"STRING",
+      "description": "Goals scored"
+    },
+    {
+      "name":"Assists",
+      "type":"STRING",
+      "description": "Assists made"
+    },
+    {
+      "name":"Yel",
+      "type":"STRING",
+      "description": "Yellow cards received"
+    },
+    {
+      "name":"Red",
+      "type":"STRING",
+      "description": "Red cards received"
+    },
+    {
+      "name":"SpG",
+      "type":"STRING",
+      "description": "Shots per game"
+    },
+    {
+      "name":"PS_",
+      "type":"STRING",
+      "description": "Pass success percentage"
+    },
+    {
+      "name":"AerialsWon",
+      "type":"STRING",
+      "description": "Aerial duels won per game"
+    },
+    {
+      "name":"MotM",
+      "type":"STRING",
+      "description": "Man of the Match"
+    },
+    {
+      "name":"Season",
+      "type":"STRING",
+      "description": "League Season"
+    },
+    {
+      "name":"CreatedAt",
+      "type":"TIMESTAMP",
+      "description": "Timestamp when data is ingested"
+    },
+    {
+      "name":"UpdatedAt",
+      "type":"TIMESTAMP",
+      "description": "Timestamp when data is updated"
+    }
+  ]

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -4,6 +4,7 @@ variable "project" {
 
 locals {
   data_lake_bucket = "epl_data_lake"
+  player_stats_schema = file("./resources/schema/player_stats_data.json")
 }
 
 variable "credentials_file" {}


### PR DESCRIPTION
### Context

Instead of directly creating the `player_stats_data` table in `BigQuery`, we want to manage the creation of this infrastructure in the terraform.

### Solution

I defined a resource called `google_bigquery_table` to create the `player_stats_data` table, and within it, I added the schema. With regards to the `schema`, I added a `json` file called `player_stats_data.json` in the `./resources/schema` directory.

### Checklist to Production
- [x] I have commented my code when necessary, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have performed a code styling check