### PR TITLE
Integrate premier league player data

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -55,6 +55,8 @@ resource "google_bigquery_table" "player_demo_data" {
 
   schema = local.player_demo_schema
 
+  deletion_protection = false
+
   # Define clustering configuration
   clustering = ["Season", "Club", "Position", "Nationality"]
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -46,3 +46,16 @@ resource "google_bigquery_table" "player_stats_data" {
   clustering = ["Season"]
 
   }
+
+# Player Demographics Table
+resource "google_bigquery_table" "player_demo_data" {
+  project = var.project
+  dataset_id = var.big_query_dataset
+  table_id = "player_demo_data"
+
+  schema = local.player_demo_schema
+
+  # Define clustering configuration
+  clustering = ["Season", "Club", "Position", "Nationality"]
+
+  }

--- a/infrastructure/terraform/resources/schema/player_data_football_critic.json
+++ b/infrastructure/terraform/resources/schema/player_data_football_critic.json
@@ -1,0 +1,67 @@
+[
+    {
+      "name":"Player Names",
+      "type":"STRING",
+      "description": "Player full names"
+    },
+    {
+      "name":"Club",
+      "type":"STRING",
+      "description": "Player's current club"
+    },
+    {
+      "name":"Nationality",
+      "type":"STRING",
+      "description": "Player's nationality"
+    },
+    {
+      "name":"Age",
+      "type":"STRING",
+      "description": "Player's age"
+    },
+    {
+      "name":"DOB",
+      "type":"STRING",
+      "description": "Player's age"
+    },
+    {
+      "name":"Position",
+      "type":"STRING",
+      "description": "Player's position in field"
+    },
+    {
+      "name":"Prefered_Foot",
+      "type":"STRING",
+      "description": "Player's preferred foot"
+    },
+    {
+      "name":"Height",
+      "type":"STRING",
+      "description": "Player's height"
+    },
+    {
+      "name":"Weight",
+      "type":"STRING",
+      "description": "Player's weight"
+    },
+    {
+      "name":"Previous_Teams",
+      "type":"STRING",
+      "description": "Player's previous teams"
+    },
+    {
+      "name":"CreatedAt",
+      "type":"TIMESTAMP",
+      "description": "Timestamp when data is ingested"
+    },
+    {
+      "name":"Season",
+      "type":"STRING",
+      "description": "League Season"
+    },
+    {
+      "name":"UpdatedAt",
+      "type":"TIMESTAMP",
+      "description": "Timestamp when data is updated"
+    }
+  ]

--- a/infrastructure/terraform/resources/schema/player_data_football_critic.json
+++ b/infrastructure/terraform/resources/schema/player_data_football_critic.json
@@ -1,6 +1,6 @@
 [
     {
-      "name":"Player Names",
+      "name":"Player_Names",
       "type":"STRING",
       "description": "Player full names"
     },
@@ -21,7 +21,7 @@
     },
     {
       "name":"DOB",
-      "type":"STRING",
+      "type":"TIMESTAMP",
       "description": "Player's age"
     },
     {

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -5,6 +5,7 @@ variable "project" {
 locals {
   data_lake_bucket = "epl_data_lake"
   player_stats_schema = file("./resources/schema/player_stats_data.json")
+  player_demo_schema = file("./resources/schema/player_data_football_critic.json")
 }
 
 variable "credentials_file" {}

--- a/src/data_integration/epl_scrappers/football_critic/el_gcs_to_bigquery.py
+++ b/src/data_integration/epl_scrappers/football_critic/el_gcs_to_bigquery.py
@@ -1,0 +1,143 @@
+import os
+import argparse
+
+from datetime import timedelta
+import pandas as pd
+from dotenv import load_dotenv
+
+from prefect import flow, task
+from prefect_gcp import GcpCredentials
+from prefect.tasks import task_input_hash
+from prefect_gcp.cloud_storage import GcsBucket
+
+
+# Take env variables from .env
+load_dotenv()
+
+# Catch env variables
+project_id = os.getenv('project_id')
+player_stats_dataset = os.getenv('epl_analytics_dwh')
+player_demo_table = os.getenv('player_demo_table')
+
+
+@task(name='extract from GCS', retries=2,
+      cache_expiration=timedelta(microseconds=1),
+      cache_key_fn=task_input_hash)
+def extract_from_gcs_to_local(gcs_file_path: str) -> str:
+    """Download objects within a folder
+    from the bucket
+
+    Args:
+    -----
+    gcs_file_path : str
+        Folder path in GCS
+
+    Returns:
+        local file path to data
+    """
+
+    gcp_cloud_storage_bucket = GcsBucket.load("epl-gcs-bucket")
+
+    gcp_cloud_storage_bucket.get_directory(
+        from_path=gcs_file_path,
+        local_path='./'
+    )
+
+    return f'./{gcs_file_path}'
+
+
+@task(name='Transform to DataFrame', retries=2)
+def transform_to_df(data_file_path: str):
+    """Load data into Pandas DataFrame
+
+    Args:
+    -----
+    data_file_path : str
+        file path to data
+
+    Returns:
+    --------
+        df : pd.DataFrame
+    """
+
+    df = pd.read_parquet(data_file_path)
+
+    # Rename columns
+    df.rename(
+        columns={
+            'Player Names': 'Player_Names',
+            'Prefered Foot': 'Prefered_Foot',
+            'Previous Teams': 'Previous_Teams'
+        },
+        inplace=True
+    )
+
+    return df
+
+
+@task(name='load to BigQuery', retries=2,
+      cache_expiration=timedelta(hours=1),
+      cache_key_fn=task_input_hash)
+def load_to_bq(df: pd.DataFrame) -> None:
+    """Load DataFrame to BigQuery
+
+    Args:
+    df : pd.DataFrame
+        A pandas DataFrame with EPL stats data
+
+    Returns:
+        None
+    """
+
+    gcp_credentials = GcpCredentials.load("epl-analytics-gcs-credentials")
+
+    df.to_gbq(
+        project_id=project_id,
+        destination_table=player_demo_table,
+        credentials=gcp_credentials.get_credentials_from_service_account(),
+        chunksize=300,
+        if_exists="append"
+    )
+
+
+@flow(name='GCS to BigQuery')
+def etl(gcs_file_path: str):
+    """Flow responsible for call func
+    to get data from GCS to BigQuery
+
+    Args:
+    -----
+    gcs_folder_path : str
+        Folder path in GCS
+
+    Returns:
+    --------
+        None
+    """
+
+    # Load data to BigQuery
+    file_path = extract_from_gcs_to_local(gcs_file_path)
+    # Transform data
+    df = transform_to_df(file_path)
+    # Load data to BigQuery
+    load_to_bq(df)
+
+
+if __name__ == '__main__':
+
+    arg_parser = argparse.ArgumentParser(
+        description='Pass Season Year and Tag'
+    )
+    arg_parser.add_argument('--season_year', type=str, required=True)
+
+    season = arg_parser.parse_args().season_year
+
+    current_local_path = os.path.dirname(__file__)
+
+    GCS_PATH = (
+        f'epl_player_data_repository/{season}/'
+        f'epl_player_data.gz.parquet'
+    )
+
+    # Extract data from GCS to BigQuery
+    etl(GCS_PATH)

--- a/src/data_integration/epl_scrappers/football_critic/el_web_to_gcs.py
+++ b/src/data_integration/epl_scrappers/football_critic/el_web_to_gcs.py
@@ -1,0 +1,217 @@
+""" EL to extract EPL data and load it to GCS """
+
+import time
+import argparse
+from datetime import timedelta
+import pandas as pd
+
+import utils
+
+from prefect import flow, task
+from prefect.tasks import task_input_hash
+from prefect_gcp.cloud_storage import GcsBucket
+
+from selenium import webdriver
+from selenium.common import exceptions
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+@task(name='Extract Player Data', retries=2,
+      cache_expiration=timedelta(days=1),
+      cache_key_fn=task_input_hash)
+def extract_player_data(crawl_url: str):
+    """Crawl FootballCritic website, extract players
+    data, and load it into a Pandas DataFrame
+
+    Args:
+    -----
+    crawl_url : str
+        EPL website
+
+    Returns:
+    --------
+        Pandas DataFrame with EPL Demographic Data
+    """
+    # Dictionary to store player info
+    player_info = {
+        'Player Names': [],
+        'Club': [],
+        'Nationality': [],
+        'Age': [],
+        'Position': [],
+        'Prefered Foot': [],
+        'Height': [],
+        'Weight': [],
+        'Previous Teams': [],
+        'CreatedAt': [],
+        'UpdatedAt': []
+    }
+
+    driver = webdriver.Chrome()
+    # Open web browser
+    driver.get(url=crawl_url)
+
+    # Find `Accept All Cookies` btn and click it
+    accept_cookies_btn = WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located(
+            (By.XPATH, "//button[@class=' css-47sehv' and \
+             contains(., 'AGREE')]"))
+    )
+    accept_cookies_btn.click()
+
+    # Cancel `Push Notifications` message
+    accept_cookies_btn = WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located(
+            (By.XPATH,
+             "//button[@id='onesignal-slidedown-cancel-button' \
+                and contains(., 'Later')]"))
+    )
+    accept_cookies_btn.click()
+
+    # Wait for `10` secs
+    time.sleep(10)
+
+    # Find the total height of the page
+    total_height = driver.execute_script(
+        "return Math.max( document.body.scrollHeight, "
+        "document.body.offsetHeight, "
+        "document.documentElement.clientHeight, "
+        "document.documentElement.scrollHeight, "
+        "document.documentElement.offsetHeight );"
+    )
+
+    # Scroll to the middle of the page
+    middle_position = total_height // 4
+    driver.execute_script(f"window.scrollTo(0, {middle_position});")
+    time.sleep(5)
+
+    try:
+        page_num = 1
+        while page_num <= 22:
+            # Find element with player name
+            players = driver.find_elements(
+                By.XPATH, '//a[@class="only_desktop"]')
+
+            # Loop through all player's information
+            for player in players:
+                # Find player name
+                player_info['Player Names'].append(player.text)
+                print(player.text)
+
+                # Get href attribute from `player` element
+                href = player.get_attribute('href')
+
+                # Open player info page in a new window
+                driver.execute_script(f"window.open('{href}', '_blank');")
+                # Switch to the newly opened window
+                driver.switch_to.window(driver.window_handles[1])
+                # # Navigate to player info page
+                time.sleep(5)
+
+                # Find elements with player information
+                information = driver.find_element(
+                    By.XPATH, '//ul[@class="add-info"]')
+                information_list = information.text.split("\n")
+                player_info = utils.add_player_details(
+                    information_list, player_info)
+
+                # Close the player info window
+                driver.close()
+                # Switch back to the main window
+                driver.switch_to.window(driver.window_handles[0])
+                time.sleep(3)
+
+            next_page_btn = WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable(
+                    (By.XPATH, '//a[@class="paginate_button next" and \
+                     contains(., "Next")]'))
+            )
+            # Scroll to the element using JavaScript
+            driver.execute_script(
+                "arguments[0].scrollIntoView(true);", next_page_btn)
+            # Click the "Next" button using JavaScript
+            driver.execute_script("arguments[0].click();", next_page_btn)
+            time.sleep(2)
+
+            page_num += 1
+
+    except exceptions.TimeoutException:
+        pass
+
+    return pd.DataFrame(
+        data=player_info
+    )
+
+
+@task(name='Load data to GCS', retries=2, cache_key_fn=task_input_hash,
+      cache_expiration=timedelta(hours=1))
+def load_to_gcs(player_stats_df: pd.DataFrame, epl_season: str,
+                data_file_name: str):
+    """Load transformed data into Google
+    Cloud Storage Bucket
+    Args:
+    -----
+    player_stats_df : pd.DataFrame
+        EPL player stats dataframe
+    epl_season : str
+        EPL Season
+    dataset_file_name : str
+        EPL dataset file name
+
+    Returns:
+    --------
+        None
+    """
+
+    gcp_cloud_storage_bucket_block = GcsBucket.load("epl-gcs-bucket")
+
+    gcp_cloud_storage_bucket_block.upload_from_dataframe(
+        df=player_stats_df,
+        to_path=f'epl_player_data_repository/{epl_season}/{data_file_name}.parquet',
+        serialization_format='parquet_gzip'
+    )
+
+
+@flow(name='Get Premier League Data')
+def etl(url: str, season: str, dataset_file_name: str) -> None:
+    """ETL function to extract, transform, and
+    load data it into GCS
+
+    Args:
+    -----
+    url : str
+        URL to EPL website
+    season : str
+        EPL Season
+    dataset_file_name : str
+        EPL dataset file name
+
+    Returns:
+        None
+    """
+
+    # Extract data
+    data_frame = extract_player_data(crawl_url=url)
+    # Load to GCS
+    load_to_gcs(data_frame, season, dataset_file_name)
+
+
+if __name__ == '__main__':
+
+    arg_parser = argparse.ArgumentParser(
+        description='Pass Season Year and Tag'
+    )
+    arg_parser.add_argument('--season_year', type=str, required=True)
+    arg_parser.add_argument('--season_tag', type=str, required=True)
+
+    season = arg_parser.parse_args().season_year
+    tag = arg_parser.parse_args().season_tag
+
+    DATASET_FILE_NAME = 'epl_player_data'
+
+    # Construct URL
+    web_url = f'https://www.footballcritic.com/premier-league/season-{season}/player-stats/all/2/{tag}'
+
+    etl(url=web_url, season=season, dataset_file_name=DATASET_FILE_NAME)

--- a/src/data_integration/epl_scrappers/football_critic/utils.py
+++ b/src/data_integration/epl_scrappers/football_critic/utils.py
@@ -1,0 +1,76 @@
+""" Utility functions for the ELT """
+
+from datetime import datetime
+import numpy as np
+
+
+def fill_missing_attribute_with_nan(info_dict: str) -> dict:
+    """Compare the length of `Player Names` with that
+    of other attributes, and fill in attributes with
+    not matching length with NaN values.
+    
+    Args:
+    -----
+    info_dict : dict
+        Dictionary with player information
+
+    Returns:
+        info_dict : dict
+    """
+
+    player_atts = [
+        'Club', 'Nationality', 'Age', 'Position', 'Prefered Foot',
+        'Height', 'Weight', 'Previous Teams'
+        ]
+
+    for att in player_atts:
+        if len(info_dict['Player Names']) != len(info_dict[att]):
+            info_dict[att].append(np.nan)
+
+    return info_dict
+
+
+def add_player_details(details: list, info_dict: dict) -> dict:
+    """Takes a list of player details, extracts
+    the relevant player details from it, add it's to
+    the `info_dict` dictionary. In the case that
+    a detail is missing, if fills it in with NaN
+
+    Args:
+    -----
+    details : list
+        List of player details
+    info_dict : list
+        Dictionary with player information
+
+    Returns:
+    --------
+        info_dict : dict
+    """
+
+    # Add player details available
+    for index, detail in enumerate(details, start=0):
+        if detail == 'Club:':
+            info_dict['Club'].append(details[index + 1])
+        if detail == 'Nationality:':
+            info_dict['Nationality'].append(details[index + 1])
+        if detail == 'Age:':
+            info_dict['Age'].append(details[index + 1])
+        if detail == 'Position:':
+            info_dict['Position'].append(details[index + 1])
+        if detail == 'Prefered foot:':
+            info_dict['Prefered Foot'].append(details[index + 1])
+        if detail == 'Height:':
+            info_dict['Height'].append(details[index + 1])
+        if detail == 'Weight:':
+            info_dict['Weight'].append(details[index + 1])
+        if detail == 'Previous teams:':
+            info_dict['Previous Teams'].append(details[index + 1])
+
+    # Update `CreatedAt` and `UpdatedAt`
+    cur_datetime = datetime.utcnow()
+    info_dict['CreatedAt'].append(cur_datetime)
+    info_dict['UpdatedAt'].append(cur_datetime)
+
+    # Fill in player details missing
+    return fill_missing_attribute_with_nan(info_dict)


### PR DESCRIPTION
## Context
We want to scrap EPL data from various websites, and load it into our Data Warehouse for visualization later on.

## Solution
I extended our web-scrappers to include another ETL that scraps data from `football-critic`, loads into the `Google Cloud Storage` and moves it into `BigQuery`.

## Checklist to Production
- [x] I have commented my code when necessary, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have performed a code styling check
