### PR TITLE
fix: fixed who scores data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,15 @@ Load: After the data is extracted and minimal transformations have been performe
 The resulting Dashboard is designed to show an overview of English Premier League stats, and player demographic. On it, an end user can filter the data on the EPL Season,  Club or Age.
 
 ![Overview](assets/epl-analytics-dashboard-1.png)
-![Data-dump](assets/epl-analytics-dashboard-2.png)
+
+
+### Application Setup
+
+This section outlines how to reproduce the project on your machine.
+
+#### Environment Variables
+Here is a list of the environment variables
+* `PROJECT_ID:` Google Cloud Platform Project ID
+* `PLAYER_STATS_TABLE:` Name of the BigQuery Table containing player stats data. This is how the variable is formatted: big_query_dataset.player_stats_table
+* `PLAYER_DEMO_TABLE:` Name of the BigQuery Table containing demographic data. This is how the variable is formatted: big_query_dataset.player_demo_table
+* `DRIVER_NAME`: Selenium driver that will be used to scrape data. Here, we provide the browser name. E.g. FireFox, Chrome, etc

--- a/src/data_integration/epl_scrappers/football_critic/el_gcs_to_bigquery.py
+++ b/src/data_integration/epl_scrappers/football_critic/el_gcs_to_bigquery.py
@@ -15,9 +15,8 @@ from prefect_gcp.cloud_storage import GcsBucket
 load_dotenv()
 
 # Catch env variables
-project_id = os.getenv('project_id')
-player_stats_dataset = os.getenv('epl_analytics_dwh')
-player_demo_table = os.getenv('player_demo_table')
+project_id = os.getenv('PROJECT_ID')
+player_demo_table = os.getenv('PLAYER_DEMO_TABLE')
 
 
 @task(name='extract from GCS', retries=2,

--- a/src/data_integration/epl_scrappers/who_scored/etl_gcs_to_bigquery.py
+++ b/src/data_integration/epl_scrappers/who_scored/etl_gcs_to_bigquery.py
@@ -15,9 +15,8 @@ from prefect_gcp.cloud_storage import GcsBucket
 load_dotenv()
 
 # Catch env variables
-project_id = os.getenv('project_id')
-player_stats_dataset = os.getenv('epl_analytics_dwh')
-player_stats_table = os.getenv('player_stats_table')
+project_id = os.getenv('PROJECT_ID')
+player_stats_table = os.getenv('PLAYER_STATS_TABLE')
 
 
 @task(name='extract from GCS', retries=2,


### PR DESCRIPTION
### Context

We want to ensure that our data-pipelines are still functional in scraping data from our sources.

### Solution

Assessed data-pipeline getting data from whoscored. Removed code that clicks on push notification as the page loads. Implication: Once the website is loaded by Selenium, the user has to manually close the push notification page.

### Checklist to Production
- [x] I have commented my code when necessary, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have performed a code styling check